### PR TITLE
[FIX] JAR 복사 로직 개선

### DIFF
--- a/.github/workflows/main_cd_workflow.yml
+++ b/.github/workflows/main_cd_workflow.yml
@@ -36,8 +36,11 @@ jobs:
       # Actuator 포함 여부 검증
       - name: Assert actuator present
         run: |
-          jar tf build/libs/ouch.jar | grep spring-boot-actuator || {
-            echo "❌ Actuator not in JAR"; exit 1; }
+          JAR=$(ls -t build/libs/*.jar | head -n1)
+          echo "Checking newest JAR: $JAR"
+          jar tf "$JAR" | grep spring-boot-actuator || {
+            echo "❌ Actuator not found in $JAR"; exit 1
+          }
 
       - name: docker login
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends curl \
  && rm -rf /var/lib/apt/lists/*
 
-ARG JAR_FILE=build/libs/sumte.jar
+ARG JAR_FILE=build/libs/*.jar
 
-COPY ${JAR_FILE} app.jar
+COPY ${JAR_FILE} sumte.jar
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=5 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "sumte.jar"]


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## ✨ PR 세부 내용

### Dockerfile
- `ARG JAR_FILE=build/libs/*.jar` 와일드카드 사용으로, 빌드 결과물 이름에 상관없이 최신 실행용 JAR을 `sumte.jar`으로 복사하도록 수정

### GitHub Actions 빌드 워크플로우
- “Assert actuator present” 스텝에서 `ls -t build/libs/*.jar | head -n1` 로 최신 JAR 파일을 자동으로 찾아 검사하도록 개선
<!-- 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능) -->
<!-- 구현 기능 요약 -->
<!-- 주요 변경사항 -->

