### PR TITLE
[FIX] CD 워크플로우 속 docker-compose.yml 파일을 읽지 못하는 문제 수정

### DIFF
--- a/.github/workflows/main_cd_workflow.yml
+++ b/.github/workflows/main_cd_workflow.yml
@@ -62,6 +62,9 @@ jobs:
     needs: build-and-push-image
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Copy compose file
         uses: appleboy/scp-action@v0.1.4
         with:


### PR DESCRIPTION
## ✨ PR 세부 내용
- deploy Job 맨 앞에 checkout 스텝을 추가하여 docker-compose.yml 파일을 읽도록 수정

<!-- 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능) -->
<!-- 구현 기능 요약 -->
<!-- 주요 변경사항 -->
