### PR TITLE
[FEAT] 이미지 저장·조회·교체 API 구현 이미지 다중 처리 로직 구현 (#50)

### DIFF
--- a/src/main/java/com/sumte/apiPayload/code/error/ImageErrorCode.java
+++ b/src/main/java/com/sumte/apiPayload/code/error/ImageErrorCode.java
@@ -1,0 +1,24 @@
+package com.sumte.apiPayload.code.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements ErrorCode {
+	IMAGE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "IMAGE400", "해당 이미지가 이미 등록되어 있습니다."),
+
+	GUESTHOUSE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "해당 게스트하우스를 찾을 수 없습니다."),
+
+	ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "해당 룸을 찾을 수 없습니다."),
+
+	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "해당 리뷰를 찾을 수 없습니다."),
+
+	INVALID_OWNER_TYPE(HttpStatus.BAD_REQUEST, "IMAGE400", "지원하지 않는 이미지 소유자 타입입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/sumte/guesthouse/controller/GuesthouseController.java
+++ b/src/main/java/com/sumte/guesthouse/controller/GuesthouseController.java
@@ -87,6 +87,7 @@ public class GuesthouseController {
 	// }
 
 	@GetMapping("/home")
+	@Operation(summary = "홈 화면 조회", description = "홈 화면에 출력할 홈 화면 전용 게스트하우스 조회 API입니다.")
 	public ResponseEntity<ApiResponse<Slice<GuesthouseResponseDTO.HomeSummary>>> getGuesthousesForHome(
 		@ParameterObject
 		@PageableDefault(size = 10) Pageable pageable) {

--- a/src/main/java/com/sumte/guesthouse/controller/GuesthouseController.java
+++ b/src/main/java/com/sumte/guesthouse/controller/GuesthouseController.java
@@ -36,7 +36,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@Tag(name = "게스트 하우스 관련 api", description = "게스트하우스 생성/수정/조회/삭제 api 입니다.")
+@Tag(name = "게스트 하우스 api", description = "게스트하우스 생성/수정/조회/삭제 api 입니다.")
 @RequiredArgsConstructor
 @RequestMapping("/guesthouse")
 public class GuesthouseController {

--- a/src/main/java/com/sumte/guesthouse/controller/GuesthouseController.java
+++ b/src/main/java/com/sumte/guesthouse/controller/GuesthouseController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.sumte.apiPayload.ApiResponse;
 import com.sumte.apiPayload.exception.annotation.CheckPage;
 import com.sumte.apiPayload.exception.annotation.CheckPageSize;
+import com.sumte.guesthouse.dto.GuesthouseDetailDTO;
 import com.sumte.guesthouse.dto.GuesthousePreviewDTO;
 import com.sumte.guesthouse.dto.GuesthouseRequestDTO;
 import com.sumte.guesthouse.dto.GuesthouseResponseDTO;
@@ -113,10 +114,10 @@ public class GuesthouseController {
 	@Parameters({
 		@Parameter(name = "guesthouseId", description = "게스트하우스 아이디를 넘겨주세요.")
 	})
-	public ResponseEntity<ApiResponse<GuesthouseResponseDTO.GetHouseResponse>> getRoom(
+	public ResponseEntity<ApiResponse<GuesthouseDetailDTO>> getRoom(
 		@PathVariable Long guesthouseId
 	) {
-		GuesthouseResponseDTO.GetHouseResponse result = guesthouseQueryService.getHouseById(guesthouseId);
+		GuesthouseDetailDTO result = guesthouseQueryService.getHouseById(guesthouseId);
 		return ResponseEntity.ok(ApiResponse.success(result));
 	}
 

--- a/src/main/java/com/sumte/guesthouse/controller/GuesthouseController.java
+++ b/src/main/java/com/sumte/guesthouse/controller/GuesthouseController.java
@@ -69,11 +69,12 @@ public class GuesthouseController {
 	@Parameters({
 		@Parameter(name = "guesthouseId", description = "게스트하우스 아이디를 넘겨주세요")
 	})
-	public ApiResponse<Void> updateGuesthouse(
+	public ResponseEntity<Long> updateGuesthouse(
 		@PathVariable(name = "guesthouseId") Long guesthouseId,
 		@RequestBody @Valid GuesthouseRequestDTO.Update dto) {
 		guesthouseCommandService.updateGuesthouse(guesthouseId, dto);
-		return ApiResponse.successWithNoData();
+
+		return ResponseEntity.ok(guesthouseId);
 	}
 
 	// @Operation(summary = "홈 화면 게스트하우스 목록 조회 (광고 우선)", description = "게스트하우스 목록을 보여줍니다")

--- a/src/main/java/com/sumte/guesthouse/controller/OptionServiceController.java
+++ b/src/main/java/com/sumte/guesthouse/controller/OptionServiceController.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@Tag(name = "부가서비스 조회 api", description = "부가서비스 리스트를 조회하는 api 입니다.")
+@Tag(name = "게스트 하우스 api", description = "게스트하우스 생성/수정/조회/삭제 api 입니다.")
 @RequiredArgsConstructor
 @RequestMapping("/option")
 public class OptionServiceController {

--- a/src/main/java/com/sumte/guesthouse/controller/TargetAudienceController.java
+++ b/src/main/java/com/sumte/guesthouse/controller/TargetAudienceController.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@Tag(name = "이용대상 조회 api", description = "게스트하우스의 이용대상을 조회하는 api 입니다.")
+@Tag(name = "게스트 하우스 api", description = "게스트하우스 생성/수정/조회/삭제 api 입니다.")
 @RequiredArgsConstructor
 @RequestMapping("/target")
 public class TargetAudienceController {

--- a/src/main/java/com/sumte/guesthouse/converter/GuesthouseConverter.java
+++ b/src/main/java/com/sumte/guesthouse/converter/GuesthouseConverter.java
@@ -49,7 +49,6 @@ public class GuesthouseConverter {
 			.guestHouseId(guesthouse.getId())
 			.name(guesthouse.getName())
 			.addressRegion(guesthouse.getAddressRegion())
-			.imageUrl(guesthouse.getImageUrl())
 			.averageScore(avgScore)
 			.reviewCount(reviewCount)
 			.checkInTime(checkInTime)

--- a/src/main/java/com/sumte/guesthouse/dto/GuesthouseDetailDTO.java
+++ b/src/main/java/com/sumte/guesthouse/dto/GuesthouseDetailDTO.java
@@ -1,0 +1,28 @@
+package com.sumte.guesthouse.dto;
+
+import java.util.List;
+
+import com.sumte.guesthouse.entity.AdType;
+import com.sumte.room.dto.RoomResponseDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuesthouseDetailDTO {
+	private Long id;
+	private String name;
+	private String addressRegion;
+	private String addressDetail;
+	private String information;
+	private AdType advertisement;
+	private List<String> optionServices;
+	private List<String> targetAudience;
+	private List<RoomResponseDTO.GetRoomResponse> rooms;
+	private List<String> imageUrls;    // 모든 이미지 URL 리스트
+}

--- a/src/main/java/com/sumte/guesthouse/dto/GuesthouseDetailDTO.java
+++ b/src/main/java/com/sumte/guesthouse/dto/GuesthouseDetailDTO.java
@@ -23,6 +23,6 @@ public class GuesthouseDetailDTO {
 	private AdType advertisement;
 	private List<String> optionServices;
 	private List<String> targetAudience;
-	private List<RoomResponseDTO.GetRoomResponse> rooms;
+	private List<RoomResponseDTO.GetPreviewRoomByGuesthouseResponse> rooms;
 	private List<String> imageUrls;    // 모든 이미지 URL 리스트
 }

--- a/src/main/java/com/sumte/guesthouse/dto/GuesthousePreviewDTO.java
+++ b/src/main/java/com/sumte/guesthouse/dto/GuesthousePreviewDTO.java
@@ -15,16 +15,9 @@ public class GuesthousePreviewDTO {
 	private Long id;
 	private String name;
 	private Double averageScore;
-	private Long reviewCount;
+	private Integer reviewCount;
 	private Long lowerPrice;
 	private String addressRegion;
 	private LocalTime checkinTime;
-
-	public void setAverageScore(Double averageScore) {
-		this.averageScore = averageScore;
-	}
-
-	public void setReviewCount(Long reviewCount) {
-		this.reviewCount = reviewCount;
-	}
+	private String imageUrl;
 }

--- a/src/main/java/com/sumte/guesthouse/dto/GuesthouseResponseDTO.java
+++ b/src/main/java/com/sumte/guesthouse/dto/GuesthouseResponseDTO.java
@@ -60,7 +60,6 @@ public class GuesthouseResponseDTO {
 		List<String> optionServices;
 		List<String> targetAudience;
 		List<RoomResponseDTO.GetRoomResponse> rooms;
-
 	}
 
 	@Builder

--- a/src/main/java/com/sumte/guesthouse/entity/Guesthouse.java
+++ b/src/main/java/com/sumte/guesthouse/entity/Guesthouse.java
@@ -33,8 +33,6 @@ public class Guesthouse extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private AdType advertisement;
 
-	private String imageUrl;
-
 	private String information;
 
 	@OneToMany(mappedBy = "guesthouse", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -45,7 +43,6 @@ public class Guesthouse extends BaseTimeEntity {
 		guesthouse.name = dto.getName();
 		guesthouse.addressRegion = dto.getAddressRegion();
 		guesthouse.addressDetail = dto.getAddressDetail();
-		guesthouse.imageUrl = dto.getImageUrl();
 		guesthouse.information = dto.getInformation();
 		guesthouse.advertisement = AdType.NON_AD;
 		return guesthouse;
@@ -61,10 +58,6 @@ public class Guesthouse extends BaseTimeEntity {
 
 	public void setAddressDetail(String addressDetail) {
 		this.addressDetail = addressDetail;
-	}
-
-	public void setImageUrl(String imageUrl) {
-		this.imageUrl = imageUrl;
 	}
 
 	public void setInformation(String information) {

--- a/src/main/java/com/sumte/guesthouse/repository/GuesthouseRepositoryCustom.java
+++ b/src/main/java/com/sumte/guesthouse/repository/GuesthouseRepositoryCustom.java
@@ -3,9 +3,9 @@ package com.sumte.guesthouse.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.sumte.guesthouse.dto.GuesthousePreviewDTO;
 import com.sumte.guesthouse.dto.GuesthouseSearchRequestDTO;
-import com.sumte.guesthouse.entity.Guesthouse;
 
 public interface GuesthouseRepositoryCustom {
-	Page<Guesthouse> searchFiltered(GuesthouseSearchRequestDTO dto, Pageable pageable);
+	Page<GuesthousePreviewDTO> searchFiltered(GuesthouseSearchRequestDTO dto, Pageable pageable);
 }

--- a/src/main/java/com/sumte/guesthouse/repository/GuesthouseRepositoryCustom.java
+++ b/src/main/java/com/sumte/guesthouse/repository/GuesthouseRepositoryCustom.java
@@ -3,9 +3,9 @@ package com.sumte.guesthouse.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import com.sumte.guesthouse.dto.GuesthousePreviewDTO;
 import com.sumte.guesthouse.dto.GuesthouseSearchRequestDTO;
+import com.sumte.guesthouse.entity.Guesthouse;
 
 public interface GuesthouseRepositoryCustom {
-	Page<GuesthousePreviewDTO> searchFiltered(GuesthouseSearchRequestDTO dto, Pageable pageable);
+	Page<Guesthouse> searchFiltered(GuesthouseSearchRequestDTO dto, Pageable pageable);
 }

--- a/src/main/java/com/sumte/guesthouse/service/GuesthouseCommandServiceImpl.java
+++ b/src/main/java/com/sumte/guesthouse/service/GuesthouseCommandServiceImpl.java
@@ -92,9 +92,6 @@ public class GuesthouseCommandServiceImpl implements GuesthouseCommandService {
 		if (dto.getAddressDetail() != null) {
 			guesthouse.setAddressDetail(dto.getAddressDetail());
 		}
-		if (dto.getImageUrl() != null) {
-			guesthouse.setImageUrl(dto.getImageUrl());
-		}
 		if (dto.getInformation() != null) {
 			guesthouse.setInformation(dto.getInformation());
 		}

--- a/src/main/java/com/sumte/guesthouse/service/GuesthouseQueryService.java
+++ b/src/main/java/com/sumte/guesthouse/service/GuesthouseQueryService.java
@@ -4,12 +4,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import com.sumte.guesthouse.dto.GuesthouseDetailDTO;
 import com.sumte.guesthouse.dto.GuesthousePreviewDTO;
 import com.sumte.guesthouse.dto.GuesthouseResponseDTO;
 import com.sumte.guesthouse.dto.GuesthouseSearchRequestDTO;
 
 public interface GuesthouseQueryService {
-	GuesthouseResponseDTO.GetHouseResponse getHouseById(Long id);
+	GuesthouseDetailDTO getHouseById(Long id);
 
 	Page<GuesthousePreviewDTO> getFilteredGuesthouse(GuesthouseSearchRequestDTO dto, Pageable pageable);
 

--- a/src/main/java/com/sumte/guesthouse/service/GuesthouseQueryServiceImpl.java
+++ b/src/main/java/com/sumte/guesthouse/service/GuesthouseQueryServiceImpl.java
@@ -91,8 +91,8 @@ public class GuesthouseQueryServiceImpl implements GuesthouseQueryService {
 			));
 
 		// 4-c) RoomResponseDTO 리스트 생성
-		List<RoomResponseDTO.GetRoomResponse> roomDtos = rooms.stream()
-			.map(room -> RoomResponseDTO.GetRoomResponse.builder()
+		List<RoomResponseDTO.GetPreviewRoomByGuesthouseResponse> roomDtos = rooms.stream()
+			.map(room -> RoomResponseDTO.GetPreviewRoomByGuesthouseResponse.builder()
 				.id(room.getId())
 				.name(room.getName())
 				.content(room.getContents())
@@ -190,15 +190,15 @@ public class GuesthouseQueryServiceImpl implements GuesthouseQueryService {
 	@Transactional
 	public Page<GuesthousePreviewDTO> getFilteredGuesthouse(GuesthouseSearchRequestDTO dto, Pageable pageable) {
 		// 1) 필터링된 게스트하우스 페이징 조회
-		Page<Guesthouse> page = guesthouseRepositoryCustom.searchFiltered(dto, pageable);
-		List<Guesthouse> ghList = page.getContent();
+		Page<GuesthousePreviewDTO> page = guesthouseRepositoryCustom.searchFiltered(dto, pageable);
+		List<GuesthousePreviewDTO> ghList = page.getContent();
 		if (ghList.isEmpty()) {
 			return new PageImpl<>(List.of(), pageable, 0);
 		}
 
 		// 2) 조회된 게스트하우스 ID들
 		List<Long> ghIds = ghList.stream()
-			.map(Guesthouse::getId)
+			.map(GuesthousePreviewDTO::getId)
 			.toList();
 
 		// 3) 이미지 일괄 조회 (N+1 방지)

--- a/src/main/java/com/sumte/guesthouse/service/GuesthouseQueryServiceImpl.java
+++ b/src/main/java/com/sumte/guesthouse/service/GuesthouseQueryServiceImpl.java
@@ -1,27 +1,37 @@
 package com.sumte.guesthouse.service;
 
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 
 import com.sumte.apiPayload.code.error.CommonErrorCode;
 import com.sumte.apiPayload.exception.SumteException;
-import com.sumte.guesthouse.converter.GuesthouseConverter;
+import com.sumte.guesthouse.dto.GuesthouseDetailDTO;
 import com.sumte.guesthouse.dto.GuesthousePreviewDTO;
 import com.sumte.guesthouse.dto.GuesthouseResponseDTO;
 import com.sumte.guesthouse.dto.GuesthouseSearchRequestDTO;
+import com.sumte.guesthouse.entity.AdType;
 import com.sumte.guesthouse.entity.Guesthouse;
 import com.sumte.guesthouse.repository.GuesthouseOptionServicesRepository;
 import com.sumte.guesthouse.repository.GuesthouseRepository;
 import com.sumte.guesthouse.repository.GuesthouseRepositoryCustom;
 import com.sumte.guesthouse.repository.GuesthouseTargetAudienceRepository;
+import com.sumte.image.entity.Image;
+import com.sumte.image.entity.OwnerType;
+import com.sumte.image.repository.ImageRepository;
 import com.sumte.review.repository.ReviewRepository;
 import com.sumte.room.dto.RoomResponseDTO;
+import com.sumte.room.entity.Room;
 import com.sumte.room.repository.RoomRepository;
 
 import jakarta.transaction.Transactional;
@@ -34,23 +44,54 @@ public class GuesthouseQueryServiceImpl implements GuesthouseQueryService {
 	private final GuesthouseRepository guesthouseRepository;
 	private final RoomRepository roomRepository;
 	private final ReviewRepository reviewRepository;
-	private final GuesthouseConverter guesthouseConverter;
 	private final GuesthouseTargetAudienceRepository guesthouseTargetAudienceRepository;
 	private final GuesthouseOptionServicesRepository guesthouseOptionServicesRepository;
 	private final GuesthouseRepositoryCustom guesthouseRepositoryCustom;
+	private final ImageRepository imageRepository;
 
 	@Override
 	@Transactional
-	public GuesthouseResponseDTO.GetHouseResponse getHouseById(Long id) {
+	public GuesthouseDetailDTO getHouseById(Long guesthouseId) {
+		// 1) 기본 정보 로드
+		Guesthouse gh = guesthouseRepository.findById(guesthouseId)
+			.orElseThrow(() -> new SumteException(CommonErrorCode.NOT_EXIST));
 
-		Guesthouse guesthouse = guesthouseRepository.findById(id).orElseThrow(
-			() -> new SumteException(CommonErrorCode.NOT_EXIST)
-		);
+		// 2) 옵션·타깃
+		List<String> targetAudiences = guesthouseTargetAudienceRepository
+			.findTargetAudienceNamesByGuesthouseId(guesthouseId);
+		List<String> optionServices = guesthouseOptionServicesRepository
+			.findTargetAudienceNamesByGuesthouseId(guesthouseId);
 
-		List<String> targetAudiences = guesthouseTargetAudienceRepository.findTargetAudienceNamesByGuesthouseId(id);
-		List<String> optionServices = guesthouseOptionServicesRepository.findTargetAudienceNamesByGuesthouseId(id);
+		// 3) **게스트하우스가 가진 모든 이미지** 조회 & URL 리스트 변환
+		List<String> ghImageUrls = imageRepository
+			.findByOwnerTypeAndOwnerIdOrderBySortOrderAsc(OwnerType.GUESTHOUSE, guesthouseId)
+			.stream()
+			.map(Image::getUrl)
+			.toList();
 
-		List<RoomResponseDTO.GetRoomResponse> roomDtos = guesthouse.getRooms().stream()
+		// 4) 각 Room 정보 + 첫 번째 이미지
+		List<Room> rooms = gh.getRooms();
+		List<Long> roomIds = rooms.stream().map(Room::getId).toList();
+
+		// 4-a) 객실 이미지 일괄 조회
+		List<Image> roomImages = imageRepository
+			.findByOwnerTypeAndOwnerIdInOrderByOwnerIdAscSortOrderAsc(OwnerType.ROOM, roomIds);
+
+		// 4-b) 방 ID 별 첫 장 URL
+		Map<Long, String> firstImageByRoom = roomImages.stream()
+			.collect(Collectors.groupingBy(
+				Image::getOwnerId,
+				LinkedHashMap::new,
+				Collectors.mapping(Image::getUrl, Collectors.toList())
+			))
+			.entrySet().stream()
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				e -> e.getValue().get(0)
+			));
+
+		// 4-c) RoomResponseDTO 리스트 생성
+		List<RoomResponseDTO.GetRoomResponse> roomDtos = rooms.stream()
 			.map(room -> RoomResponseDTO.GetRoomResponse.builder()
 				.id(room.getId())
 				.name(room.getName())
@@ -60,40 +101,157 @@ public class GuesthouseQueryServiceImpl implements GuesthouseQueryService {
 				.checkout(room.getCheckout())
 				.standardCount(room.getStandardCount())
 				.totalCount(room.getTotalCount())
-				.imageUrl(room.getImageUrl())
+				.imageUrl(firstImageByRoom.get(room.getId()))   // 각 방 첫 장 이미지
 				.build())
-			.collect(Collectors.toList());
+			.toList();
 
-		return GuesthouseResponseDTO.GetHouseResponse.builder()
-			.id(guesthouse.getId())
-			.name(guesthouse.getName())
-			.addressDetail(guesthouse.getAddressDetail())
-			.addressRegion(guesthouse.getAddressRegion())
-			.information(guesthouse.getInformation())
-			.imageUrl(guesthouse.getImageUrl())
-			.targetAudience(targetAudiences)
+		// 5) 최종 DTO 조립
+		return GuesthouseDetailDTO.builder()
+			.id(gh.getId())
+			.name(gh.getName())
+			.addressRegion(gh.getAddressRegion())
+			.addressDetail(gh.getAddressDetail())
+			.information(gh.getInformation())
+			.advertisement(gh.getAdvertisement())
 			.optionServices(optionServices)
-			.rooms(roomDtos)
+			.targetAudience(targetAudiences)
+			.imageUrls(ghImageUrls)      // 모든 게스트하우스 이미지
+			.rooms(roomDtos)             // 각 방 + 첫 장 이미지
 			.build();
 	}
 
 	@Override
 	@Transactional
 	public Slice<GuesthouseResponseDTO.HomeSummary> getGuesthousesForHome(Pageable pageable) {
-		Slice<Guesthouse> guesthouses = guesthouseRepository.findAllOrderedForHome(pageable);
+		// 1) 페이징 혹은 슬라이스 조회
+		Slice<Guesthouse> slice = guesthouseRepository.findAllOrderedForHome(pageable);
+		List<Guesthouse> ghList = slice.getContent();
+		if (ghList.isEmpty()) {
+			return new SliceImpl<>(List.of(), pageable, false);
+		}
 
-		return guesthouses.map(gh -> guesthouseConverter.toHomeSummary(
-			gh,
-			Optional.ofNullable(reviewRepository.findAverageScoreByGuesthouseId(gh.getId())).orElse(0.0),
-			reviewRepository.countByGuesthouseId(gh.getId()),
-			Optional.ofNullable(roomRepository.findEarliestCheckinByGuesthouseId(gh.getId())).orElse("00:00"),
-			Optional.ofNullable(roomRepository.findMinPriceByGuesthouseId(gh.getId())).orElse(0L)
-		));
+		// 2) ID 리스트 & 이미지 조회
+		List<Long> ghIds = ghList.stream().map(Guesthouse::getId).toList();
+		List<Image> images = imageRepository
+			.findByOwnerTypeAndOwnerIdInOrderByOwnerIdAscSortOrderAsc(
+				OwnerType.GUESTHOUSE, ghIds
+			);
+		Map<Long, String> firstImageByGh = images.stream()
+			.collect(Collectors.groupingBy(
+				Image::getOwnerId,
+				LinkedHashMap::new,
+				Collectors.mapping(Image::getUrl, Collectors.toList())
+			))
+			.entrySet().stream()
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				e -> e.getValue().get(0)
+			));
+
+		// 3) DTO 변환
+		List<GuesthouseResponseDTO.HomeSummary> summaries = ghList.stream()
+			.map(gh -> GuesthouseResponseDTO.HomeSummary.builder()
+				.guestHouseId(gh.getId())
+				.name(gh.getName())
+				.addressRegion(gh.getAddressRegion())
+				.imageUrl(firstImageByGh.getOrDefault(gh.getId(), null))
+				.averageScore(
+					Optional.ofNullable(
+						reviewRepository.findAverageScoreByGuesthouseId(gh.getId())
+					).orElse(0.0)
+				)
+				.reviewCount(
+					reviewRepository.countByGuesthouseId(gh.getId())
+				)
+				.checkInTime(
+					Optional.ofNullable(
+						roomRepository.findEarliestCheckinByGuesthouseId(gh.getId())
+					).orElse("00:00")
+				)
+				.minPrice(
+					Optional.ofNullable(
+						roomRepository.findMinPriceByGuesthouseId(gh.getId())
+					).orElse(0L)
+				)
+				.isAd(gh.getAdvertisement() == AdType.AD)
+				.build()
+			)
+			.toList();
+
+		// 4) SliceImpl 생성해 반환
+		return new SliceImpl<>(
+			summaries,
+			pageable,
+			slice.hasNext()
+		);
 	}
 
 	@Override
 	@Transactional
 	public Page<GuesthousePreviewDTO> getFilteredGuesthouse(GuesthouseSearchRequestDTO dto, Pageable pageable) {
-		return guesthouseRepositoryCustom.searchFiltered(dto, pageable);
+		// 1) 필터링된 게스트하우스 페이징 조회
+		Page<Guesthouse> page = guesthouseRepositoryCustom.searchFiltered(dto, pageable);
+		List<Guesthouse> ghList = page.getContent();
+		if (ghList.isEmpty()) {
+			return new PageImpl<>(List.of(), pageable, 0);
+		}
+
+		// 2) 조회된 게스트하우스 ID들
+		List<Long> ghIds = ghList.stream()
+			.map(Guesthouse::getId)
+			.toList();
+
+		// 3) 이미지 일괄 조회 (N+1 방지)
+		List<Image> images = imageRepository
+			.findByOwnerTypeAndOwnerIdInOrderByOwnerIdAscSortOrderAsc(
+				OwnerType.GUESTHOUSE, ghIds
+			);
+
+		// 4) ownerId 별로 첫 번째 URL만 뽑아서 맵으로 저장
+		Map<Long, String> firstImageByGh = images.stream()
+			.collect(Collectors.groupingBy(
+				Image::getOwnerId,
+				LinkedHashMap::new,                         // key 순서 보장(Optional)
+				Collectors.mapping(Image::getUrl, Collectors.toList())
+			))
+			.entrySet().stream()
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				e -> e.getValue().get(0)                  // 리스트의 첫 번째 URL
+			));
+
+		// 5) DTO 변환
+		List<GuesthousePreviewDTO> dtos = ghList.stream()
+			.map(gh -> GuesthousePreviewDTO.builder()
+				.id(gh.getId())
+				.name(gh.getName())
+				.averageScore(
+					Optional.ofNullable(
+						reviewRepository.findAverageScoreByGuesthouseId(gh.getId())
+					).orElse(0.0)
+				)
+				.reviewCount(
+					reviewRepository.countByGuesthouseId(gh.getId())
+				)
+				.lowerPrice(
+					Optional.ofNullable(
+						roomRepository.findMinPriceByGuesthouseId(gh.getId())
+					).orElse(0L)
+				)
+				.addressRegion(gh.getAddressRegion())
+				.checkinTime(
+					LocalTime.parse(Optional.ofNullable(
+						roomRepository.findEarliestCheckinByGuesthouseId(gh.getId())
+					).orElse("00:00"))
+				)
+				.imageUrl(
+					firstImageByGh.getOrDefault(gh.getId(), null)
+				)
+				.build()
+			)
+			.toList();
+
+		// 6) PageImpl 으로 감싸서 반환
+		return new PageImpl<>(dtos, pageable, page.getTotalElements());
 	}
 }

--- a/src/main/java/com/sumte/image/controller/ImageController.java
+++ b/src/main/java/com/sumte/image/controller/ImageController.java
@@ -82,17 +82,17 @@ public class ImageController {
 	@PostMapping
 	public ResponseEntity<List<ImageResponseDTO>> saveImagesBatch(
 
-		@Valid @RequestBody List<ImageRequestDTO> dtos) {
+		@Valid @RequestBody List<ImageRequestDTO> imageRequestDTOS) {
 
-		var savedList = imageService.saveAllImages(dtos);
-		var respList = savedList.stream()
+		var savedImageList = imageService.saveAllImages(imageRequestDTOS);
+		var imageResponseDTOS = savedImageList.stream()
 			.map(img -> new ImageResponseDTO(
 				img.getId(), img.getUrl(), img.getSortOrder(), img.getOwnerType(), img.getOwnerId()))
 			.collect(Collectors.toList());
 
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
-			.body(respList);
+			.body(imageResponseDTOS);
 	}
 
 	@Operation(
@@ -132,8 +132,8 @@ public class ImageController {
 			.map(r -> new ImageRequestDTO(ownerType, ownerId, r.getUrl()))
 			.collect(Collectors.toList());
 
-		var saved = imageService.replaceImages(ownerType, ownerId, requests);
-		var resp = saved.stream()
+		var replacedImages = imageService.replaceImages(ownerType, ownerId, requests);
+		var imageResponseDTOS = replacedImages.stream()
 			.map(img -> new ImageResponseDTO(
 				img.getId(),
 				img.getUrl(),
@@ -143,7 +143,7 @@ public class ImageController {
 			))
 			.collect(Collectors.toList());
 
-		return ResponseEntity.ok(resp);
+		return ResponseEntity.ok(imageResponseDTOS);
 	}
 
 	@Operation(summary = "이미지 목록 조회", description = "주어진 ownerType, ownerId 에 매핑된 이미지 리스트를 정렬순으로 조회합니다.")
@@ -164,11 +164,11 @@ public class ImageController {
 			in = ParameterIn.QUERY
 		)
 		@RequestParam Long ownerId) {
-		var list = imageService.getImagesByOwner(ownerType, ownerId);
-		var dtos = list.stream()
+		var imageList = imageService.getImagesByOwner(ownerType, ownerId);
+		var imageResponseDTOS = imageList.stream()
 			.map(img -> new ImageResponseDTO(
 				img.getId(), img.getUrl(), img.getSortOrder(), img.getOwnerType(), img.getOwnerId()))
 			.collect(Collectors.toList());
-		return ResponseEntity.ok(dtos);
+		return ResponseEntity.ok(imageResponseDTOS);
 	}
 }

--- a/src/main/java/com/sumte/image/controller/ImageController.java
+++ b/src/main/java/com/sumte/image/controller/ImageController.java
@@ -41,7 +41,7 @@ public class ImageController {
 	@Operation(summary = "이미지 일괄 저장",
 		description = """
 			- 여러 이미지 메타데이터를 한 번에 저장합니다.
-			- 이미지가 등록되는 파트에 대한 정보 OwnerType(GUESTHOUSE, ROOM 등)과
+			- 이미지가 등록되는 파트에 대한 정보 OwnerType(GUESTHOUSE, ROOM, REVIEW)과
 			OwnerId(해당 파트의 ID)를 함께 전달해야 합니다.
 			- 요청 리스트 순서대로 서버에서 sortOrder(이미지 순서)가 1부터 자동 부여됩니다.
 			""")

--- a/src/main/java/com/sumte/image/controller/ImageController.java
+++ b/src/main/java/com/sumte/image/controller/ImageController.java
@@ -1,0 +1,174 @@
+package com.sumte.image.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sumte.image.dto.ImageRequestDTO;
+import com.sumte.image.dto.ImageResponseDTO;
+import com.sumte.image.dto.ReplaceImageRequestDTO;
+import com.sumte.image.entity.OwnerType;
+import com.sumte.image.service.ImageService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+@Tag(name = "이미지 API", description = "이미지 메타데이터 저장·조회·교체 API 및 S3 PresignedUrl 발급 API")
+public class ImageController {
+	private final ImageService imageService;
+
+	@Operation(summary = "이미지 일괄 저장",
+		description = """
+			- 여러 이미지 메타데이터를 한 번에 저장합니다.
+			- 이미지가 등록되는 파트에 대한 정보 OwnerType(GUESTHOUSE, ROOM 등)과
+			OwnerId(해당 파트의 ID)를 함께 전달해야 합니다.
+			- 요청 리스트 순서대로 서버에서 sortOrder(이미지 순서)가 1부터 자동 부여됩니다.
+			""")
+	@io.swagger.v3.oas.annotations.parameters.RequestBody(
+		description = "등록할 이미지 리스트를 전달합니다. 서버가 순서를 1부터 자동 부여합니다.",
+		required = true,
+		content = @Content(
+			mediaType = "application/json",
+			array = @ArraySchema(
+				schema = @Schema(implementation = ImageRequestDTO.class)
+			),
+			examples = {
+				@ExampleObject(
+					name = "Image Batch Upload Example",
+					value = """
+						[
+						  {
+							"ownerType": "GUESTHOUSE",
+							"ownerId": 1,
+							"url": "https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte1.png"
+						  },
+						  {
+							"ownerType": "GUESTHOUSE",
+							"ownerId": 1,
+							"url": "https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte2.png"
+						  },
+						  {
+							"ownerType": "GUESTHOUSE",
+							"ownerId": 1,
+							"url": "https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte3.png"
+						  }
+						]
+						"""
+				)
+			}
+		)
+	)
+	@PostMapping
+	public ResponseEntity<List<ImageResponseDTO>> saveImagesBatch(
+
+		@Valid @RequestBody List<ImageRequestDTO> dtos) {
+
+		var savedList = imageService.saveAllImages(dtos);
+		var respList = savedList.stream()
+			.map(img -> new ImageResponseDTO(
+				img.getId(), img.getUrl(), img.getSortOrder(), img.getOwnerType(), img.getOwnerId()))
+			.collect(Collectors.toList());
+
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.body(respList);
+	}
+
+	@Operation(
+		summary = "이미지 전체 교체",
+		description = """
+			  주어진 ownerType/ownerId 에 등록된 모든 이미지를 삭제하고,
+			  요청 리스트 순서대로 새 이미지를 1부터 순차 저장합니다.
+			  - S3 객체도 함께 삭제됩니다.
+			""")
+	@PutMapping("/{ownerType}/{ownerId}")
+	public ResponseEntity<List<ImageResponseDTO>> replaceImages(
+		@PathVariable OwnerType ownerType,
+		@PathVariable Long ownerId,
+		@io.swagger.v3.oas.annotations.parameters.RequestBody(
+			description = "전체 교체할 이미지 리스트를 전달합니다.",
+			required = true,
+			content = @Content(
+				mediaType = "application/json",
+				array = @ArraySchema(schema = @Schema(implementation = ReplaceImageRequestDTO.class)),
+				examples = {
+					@ExampleObject(
+						name = "Replace Example",
+						value = """
+							[
+							  { "url":"https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte1.png" },
+							  { "url":"https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte2.png" },
+							  { "url":"https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte3.png" }
+							]
+							"""
+					)
+				}
+			)
+		)
+		@Valid @RequestBody List<ReplaceImageRequestDTO> replaceImageDtos
+	) {
+		List<ImageRequestDTO> requests = replaceImageDtos.stream()
+			.map(r -> new ImageRequestDTO(ownerType, ownerId, r.getUrl()))
+			.collect(Collectors.toList());
+
+		var saved = imageService.replaceImages(ownerType, ownerId, requests);
+		var resp = saved.stream()
+			.map(img -> new ImageResponseDTO(
+				img.getId(),
+				img.getUrl(),
+				img.getSortOrder(),
+				img.getOwnerType(),
+				img.getOwnerId()
+			))
+			.collect(Collectors.toList());
+
+		return ResponseEntity.ok(resp);
+	}
+
+	@Operation(summary = "이미지 목록 조회", description = "주어진 ownerType, ownerId 에 매핑된 이미지 리스트를 정렬순으로 조회합니다.")
+	@GetMapping
+	public ResponseEntity<List<ImageResponseDTO>> getImages(
+		@Parameter(
+			name = "ownerType",
+			description = "이미지 소유자 타입",
+			example = "ROOM",
+			required = true,
+			in = ParameterIn.QUERY
+		) @RequestParam OwnerType ownerType,
+		@Parameter(
+			name = "ownerId",
+			description = "소유자 ID",
+			example = "1",
+			required = true,
+			in = ParameterIn.QUERY
+		)
+		@RequestParam Long ownerId) {
+		var list = imageService.getImagesByOwner(ownerType, ownerId);
+		var dtos = list.stream()
+			.map(img -> new ImageResponseDTO(
+				img.getId(), img.getUrl(), img.getSortOrder(), img.getOwnerType(), img.getOwnerId()))
+			.collect(Collectors.toList());
+		return ResponseEntity.ok(dtos);
+	}
+}

--- a/src/main/java/com/sumte/image/controller/S3FileUploadController.java
+++ b/src/main/java/com/sumte/image/controller/S3FileUploadController.java
@@ -1,5 +1,10 @@
 package com.sumte.image.controller;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,12 +25,29 @@ public class S3FileUploadController {
 
 	private final S3FileUploadService s3FileUploadService;
 
-	//@AllUser
+	/*
 	@Operation(summary = "PresignedUrl 발급", description = "이미지, 파일 업로드를 위한 PresignedUrl을 발급합니다.")
 	@GetMapping("/presigned-url")
 	public ResponseEntity<String> generatePresignedUrl(@RequestParam String fileName,
 		@RequestParam String contentType) {
 		String presignedUrl = s3FileUploadService.generatePresignedUrl(fileName, contentType);
 		return ResponseEntity.ok(presignedUrl);
+	}
+	 */
+
+	@Operation(
+		summary = "Presigned URLs 일괄 발급",
+		description = "여러 개의 파일명에 대해 Presigned URL을 일괄 생성하여 반환합니다."
+	)
+	@GetMapping("/presigned-urls")
+	public ResponseEntity<Map<String, String>> generatePresignedUrls(
+		@RequestParam(name = "fileNames", defaultValue = "sumte1, ouchlogo") List<String> fileNames
+	) {
+		Map<String, String> presignedUrls = fileNames.stream()
+			.collect(Collectors.toMap(
+				Function.identity(),
+				key -> s3FileUploadService.generatePresignedUrl(key)
+			));
+		return ResponseEntity.ok(presignedUrls);
 	}
 }

--- a/src/main/java/com/sumte/image/controller/S3FileUploadController.java
+++ b/src/main/java/com/sumte/image/controller/S3FileUploadController.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/s3")
 @RequiredArgsConstructor
-@Tag(name = "S3 PresignedUrl API", description = "S3 PresignedUrl 발급 API")
+@Tag(name = "이미지 API", description = "이미지 메타데이터 저장·조회·교체 API 및 S3 PresignedUrl 발급 API")
 public class S3FileUploadController {
 
 	private final S3FileUploadService s3FileUploadService;

--- a/src/main/java/com/sumte/image/dto/ImageRequestDTO.java
+++ b/src/main/java/com/sumte/image/dto/ImageRequestDTO.java
@@ -1,0 +1,34 @@
+package com.sumte.image.dto;
+
+import com.sumte.image.entity.OwnerType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "ImageRequestDTO", description = "이미지 메타데이터 등록 요청 DTO")
+public class ImageRequestDTO {
+
+	@Schema(description = "이미지 소유자 타입", example = "GUESTHOUSE")
+	@NotNull
+	private OwnerType ownerType;
+
+	@Schema(description = "소유자 ID (예: 게스트하우스 ID, 룸 ID, 리뷰 ID 등)", example = "1")
+	@NotNull
+	private Long ownerId;
+
+	@Schema(description = "S3에 업로드된 이미지 URL", example = "https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte.png")
+	@NotBlank
+	private String url;
+
+	// @Schema(description = "정렬 순서 (0부터 시작)", example = "1")
+	// private Integer sortOrder;
+}

--- a/src/main/java/com/sumte/image/dto/ImageResponseDTO.java
+++ b/src/main/java/com/sumte/image/dto/ImageResponseDTO.java
@@ -1,0 +1,32 @@
+package com.sumte.image.dto;
+
+import com.sumte.image.entity.OwnerType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "ImageResponseDTO", description = "이미지 메타데이터 조회/등록 응답 DTO")
+public class ImageResponseDTO {
+
+	@Schema(description = "이미지 고유 ID", example = "1")
+	private Long id;
+
+	@Schema(description = "이미지 URL 또는 object key", example = "https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte.png")
+	private String url;
+
+	@Schema(description = "정렬 순서 (1부터 시작)", example = "1")
+	private Integer sortOrder;
+
+	@Schema(description = "이미지 소유자 타입", example = "GUESTHOUSE")
+	private OwnerType ownerType;
+
+	@Schema(description = "소유자 ID (게스트하우스/룸/리뷰 ID)", example = "1")
+	private Long ownerId;
+}

--- a/src/main/java/com/sumte/image/dto/ReplaceImageRequestDTO.java
+++ b/src/main/java/com/sumte/image/dto/ReplaceImageRequestDTO.java
@@ -1,0 +1,21 @@
+package com.sumte.image.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "ReplaceImageRequestDTO",
+	description = "이미지 전체 교체 요청 DTO (URL만 포함)")
+public class ReplaceImageRequestDTO {
+
+	@Schema(description = "S3 URL", example = "https://sumte-file.s3.ap-northeast-2.amazonaws.com/sumte.png")
+	@NotBlank
+	private String url;
+}

--- a/src/main/java/com/sumte/image/dto/S3UploadInfoDTO.java
+++ b/src/main/java/com/sumte/image/dto/S3UploadInfoDTO.java
@@ -1,0 +1,12 @@
+package com.sumte.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class S3UploadInfoDTO {
+	private String originalName;   // 클라이언트가 보낸 원본 파일명
+	private String imageUrl;       // S3에 저장될 이미지 URL
+	private String presignedUrl;   // 해당 키로 PUT 요청할 URL
+}

--- a/src/main/java/com/sumte/image/repository/ImageRepository.java
+++ b/src/main/java/com/sumte/image/repository/ImageRepository.java
@@ -21,4 +21,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 	);
 
 	List<Image> findByOwnerTypeAndOwnerIdOrderBySortOrderAsc(OwnerType ownerType, Long ownerId);
+
+	List<Image> findByOwnerTypeAndOwnerIdInOrderByOwnerIdAscSortOrderAsc(OwnerType ownerType, List<Long> ownerIds);
 }

--- a/src/main/java/com/sumte/image/repository/ImageRepository.java
+++ b/src/main/java/com/sumte/image/repository/ImageRepository.java
@@ -1,0 +1,24 @@
+package com.sumte.image.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.sumte.image.entity.Image;
+import com.sumte.image.entity.OwnerType;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+	boolean existsByOwnerTypeAndOwnerId(OwnerType ownerType, Long ownerId);
+
+	@Query("SELECT MAX(i.sortOrder) FROM Image i WHERE i.ownerType = :ownerType AND i.ownerId = :ownerId")
+	Optional<Integer> findMaxSortOrder(
+		@Param("ownerType") OwnerType ownerType,
+		@Param("ownerId") Long ownerId
+	);
+
+	List<Image> findByOwnerTypeAndOwnerIdOrderBySortOrderAsc(OwnerType ownerType, Long ownerId);
+}

--- a/src/main/java/com/sumte/image/service/ImageService.java
+++ b/src/main/java/com/sumte/image/service/ImageService.java
@@ -1,0 +1,157 @@
+package com.sumte.image.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.sumte.apiPayload.code.error.ImageErrorCode;
+import com.sumte.apiPayload.exception.SumteException;
+import com.sumte.guesthouse.repository.GuesthouseRepository;
+import com.sumte.image.dto.ImageRequestDTO;
+import com.sumte.image.entity.Image;
+import com.sumte.image.entity.OwnerType;
+import com.sumte.image.repository.ImageRepository;
+import com.sumte.review.repository.ReviewRepository;
+import com.sumte.room.repository.RoomRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+	private final ImageRepository imageRepository;
+	private final GuesthouseRepository guesthouseRepository;
+	private final RoomRepository roomRepository;
+	private final ReviewRepository reviewRepository;
+	private final AmazonS3 amazonS3Client;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucketName;
+	@Value("${cloud.aws.s3.url-prefix}")
+	private String s3UrlPrefix;
+
+	@Transactional
+	public List<Image> saveAllImages(List<ImageRequestDTO> dtos) {
+		// 1) 같은 ownerType+ownerId 그룹핑
+		Map<Pair<OwnerType, Long>, List<ImageRequestDTO>> groups = dtos.stream()
+			.collect(Collectors.groupingBy(
+				dto -> Pair.of(dto.getOwnerType(), dto.getOwnerId())
+			));
+
+		List<Image> toSave = new ArrayList<>();
+		for (var entry : groups.entrySet()) {
+			OwnerType ownerType = entry.getKey().getFirst();
+			Long ownerId = entry.getKey().getSecond();
+
+			List<ImageRequestDTO> list = entry.getValue();
+
+			// 2) 동일 owner에 이미지 이미 등록되어 있는지 검사
+			boolean existsImages = imageRepository.existsByOwnerTypeAndOwnerId(ownerType, ownerId);
+			if (existsImages) {
+				throw new SumteException(ImageErrorCode.IMAGE_ALREADY_EXISTS);
+			}
+
+			// 3) 실제 엔티티 존재 여부 검증
+			validateOwnerExists(ownerType, ownerId);
+
+			// 4) 그룹별로 DB에서 현재 최대 sortOrder 조회 → +1 부터
+			int nextOrder = imageRepository
+				.findMaxSortOrder(ownerType, ownerId)
+				.orElse(0) + 1;
+
+			// 5) 그룹 내 DTO 순서대로 sortOrder 할당
+			for (ImageRequestDTO dto : list) {
+				toSave.add(Image.builder()
+					.ownerType(ownerType)
+					.ownerId(ownerId)
+					.url(dto.getUrl())
+					.sortOrder(nextOrder++)
+					.build()
+				);
+			}
+		}
+		return imageRepository.saveAll(toSave);
+	}
+
+	/**
+	 * 전체 교체: 기존 이미지 DB 레코드와 S3 오브젝트를 전부 삭제하고,
+	 * 전달된 URL 순서대로 새 이미지를 1부터 순차 저장합니다.
+	 */
+	@Transactional
+	public List<Image> replaceImages(OwnerType ownerType, Long ownerId, List<ImageRequestDTO> imageRequestDTOS) {
+		// 1) 소유자 존재 검증
+		validateOwnerExists(ownerType, ownerId);
+
+		// 2) 기존 DB 레코드 조회
+		List<Image> existing = imageRepository
+			.findByOwnerTypeAndOwnerIdOrderBySortOrderAsc(ownerType, ownerId);
+
+		if (!existing.isEmpty()) {
+			// 3) S3 객체 키 수집 & 삭제
+			List<DeleteObjectsRequest.KeyVersion> keys = existing.stream()
+				.map(Image::getUrl)
+				// 3-1) full URL 에서 prefix 제거 → object key만 남김
+				.filter(url -> url.startsWith(s3UrlPrefix + "/"))
+				.map(url -> url.substring((s3UrlPrefix + "/").length()))
+				.map(DeleteObjectsRequest.KeyVersion::new)
+				.collect(Collectors.toList());
+
+			if (!keys.isEmpty()) {
+				DeleteObjectsRequest delReq = new DeleteObjectsRequest(bucketName)
+					.withKeys(keys);
+				amazonS3Client.deleteObjects(delReq);
+			}
+			// 4) DB 레코드 삭제
+			imageRepository.deleteAllInBatch(existing);
+		}
+
+		// 5) 새 DTO 리스트 순서대로 1부터 부여
+		List<Image> toSave = new ArrayList<>(imageRequestDTOS.size());
+		for (int i = 0; i < imageRequestDTOS.size(); i++) {
+			ImageRequestDTO dto = imageRequestDTOS.get(i);
+			toSave.add(Image.builder()
+				.ownerType(ownerType)
+				.ownerId(ownerId)
+				.url(dto.getUrl())
+				.sortOrder(i + 1)
+				.build()
+			);
+		}
+
+		// 6) 저장 후 반환
+		return imageRepository.saveAll(toSave);
+	}
+
+	private void validateOwnerExists(OwnerType ownerType, Long ownerId) {
+		switch (ownerType) {
+			case GUESTHOUSE -> {
+				if (!guesthouseRepository.existsById(ownerId)) {
+					throw new SumteException(ImageErrorCode.GUESTHOUSE_NOT_FOUND);
+				}
+			}
+			case ROOM -> {
+				if (!roomRepository.existsById(ownerId)) {
+					throw new SumteException(ImageErrorCode.ROOM_NOT_FOUND);
+				}
+			}
+			case REVIEW -> {
+				if (!reviewRepository.existsById(ownerId)) {
+					throw new SumteException(ImageErrorCode.REVIEW_NOT_FOUND);
+				}
+			}
+			default -> throw new SumteException(ImageErrorCode.INVALID_OWNER_TYPE);
+		}
+	}
+
+	public List<Image> getImagesByOwner(OwnerType ownerType, Long ownerId) {
+		return imageRepository.findByOwnerTypeAndOwnerIdOrderBySortOrderAsc(ownerType, ownerId);
+	}
+}

--- a/src/main/java/com/sumte/image/service/S3FileUploadService.java
+++ b/src/main/java/com/sumte/image/service/S3FileUploadService.java
@@ -23,7 +23,7 @@ public class S3FileUploadService {
 	private String bucket;
 
 	@Transactional
-	public String generatePresignedUrl(String fileName, String contentType) {
+	public String generatePresignedUrl(String fileName/*, String contentType*/) {
 		// 만료 시간 설정
 		Date expiration = new Date();
 		long expTimeMillis = expiration.getTime() + (1000 * 60 * 5); // 5분
@@ -34,7 +34,7 @@ public class S3FileUploadService {
 			new GeneratePresignedUrlRequest(bucket, fileName)
 				.withMethod(HttpMethod.PUT)
 				.withExpiration(expiration);
-				//.withContentType(contentType);
+		//.withContentType(contentType);
 
 		// Presigned URL 생성
 		URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);

--- a/src/main/java/com/sumte/image/service/S3FileUploadService.java
+++ b/src/main/java/com/sumte/image/service/S3FileUploadService.java
@@ -1,7 +1,11 @@
 package com.sumte.image.service;
 
-import java.net.URL;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -9,6 +13,8 @@ import org.springframework.stereotype.Service;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.sumte.image.dto.S3UploadInfoDTO;
+import com.sumte.image.entity.OwnerType;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -22,22 +28,49 @@ public class S3FileUploadService {
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 
+	@Value("${cloud.aws.s3.url-prefix}")
+	private String s3Endpoint;
+
 	@Transactional
-	public String generatePresignedUrl(String fileName/*, String contentType*/) {
+	public List<S3UploadInfoDTO> generatePresignedUrl(List<String> originalFileNames,
+		OwnerType ownerType,
+		Long ownerId /*, String contentType*/) {
+
 		// 만료 시간 설정
-		Date expiration = new Date();
-		long expTimeMillis = expiration.getTime() + (1000 * 60 * 5); // 5분
-		expiration.setTime(expTimeMillis);
+		Date expiration = new Date(System.currentTimeMillis() + 5 * 60 * 1000);
 
-		// Presigned URL 요청 생성
-		GeneratePresignedUrlRequest generatePresignedUrlRequest =
-			new GeneratePresignedUrlRequest(bucket, fileName)
-				.withMethod(HttpMethod.PUT)
-				.withExpiration(expiration);
-		//.withContentType(contentType);
+		// yyyy/MM/dd 형태의 날짜 경로
+		String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 
-		// Presigned URL 생성
-		URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
-		return url.toString();
+		return originalFileNames.stream()
+			.map(original -> {
+				// 1) 확장자 분리
+				String ext = "";
+				int idx = original.lastIndexOf('.');
+				if (idx >= 0) {
+					ext = original.substring(idx);
+				}
+
+				// 2) UUID 조합 및 전체 키 생성
+				String uuid = UUID.randomUUID().toString();
+
+				String key = "images/" + ownerType + "/"
+					+ ownerType + "_" + ownerId + "_" + datePath + "_" + uuid + ext;
+
+				// Presigned URL 요청 생성
+				GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, key)
+					.withMethod(HttpMethod.PUT)
+					.withExpiration(expiration);
+
+				// 이미지 객체 URL 생성
+				String fullUrl = s3Endpoint + "/" + key;
+
+				// Presigned URL 생성
+				String presignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+
+				return new S3UploadInfoDTO(original, fullUrl, presignedUrl);
+
+			})
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/sumte/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sumte/reservation/controller/ReservationController.java
@@ -1,32 +1,39 @@
 package com.sumte.reservation.controller;
 
-import com.sumte.apiPayload.ApiResponse;
-import com.sumte.apiPayload.exception.annotation.CheckPage;
-import com.sumte.apiPayload.exception.annotation.CheckPageSize;
-import com.sumte.security.authorization.UserId;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+import com.sumte.apiPayload.ApiResponse;
+import com.sumte.apiPayload.exception.annotation.CheckPage;
+import com.sumte.apiPayload.exception.annotation.CheckPageSize;
 import com.sumte.reservation.dto.ReservationRequestDTO;
 import com.sumte.reservation.dto.ReservationResponseDTO;
 import com.sumte.reservation.service.ReservationService;
+import com.sumte.security.authorization.UserId;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/reservations")
 @Validated
-@Tag(name = "Reservation", description = "예약 관련 API (생성, 조회, 수정, 삭제 등)")
+@Tag(name = "예약 API", description = "예약 관련 API (생성, 조회, 수정, 삭제 등)")
 public class ReservationController {
 
 	private final ReservationService reservationService;
@@ -34,8 +41,8 @@ public class ReservationController {
 	@PostMapping
 	@Operation(summary = "예약 생성 API", description = "요청 본문으로 객실 ID, 투숙 인원, 날짜 정보를 입력받고, 헤더의 userId를 통해 예약을 생성합니다.")
 	public ResponseEntity<ApiResponse<Void>> createReservation(
-			@Parameter(description = "요청한 사용자 ID") @UserId Long userId,
-			@Valid @RequestBody ReservationRequestDTO.CreateReservationDTO request
+		@Parameter(description = "요청한 사용자 ID") @UserId Long userId,
+		@Valid @RequestBody ReservationRequestDTO.CreateReservationDTO request
 	) {
 		reservationService.createReservation(request, userId);
 		return ResponseEntity.ok(ApiResponse.success(null));
@@ -44,9 +51,9 @@ public class ReservationController {
 	@GetMapping("/my")
 	@Operation(summary = "내 예약 목록 조회 API", description = "내가 예약한 숙소 목록을 페이지 단위로 조회합니다.")
 	public ResponseEntity<ApiResponse<Page<ReservationResponseDTO.MyReservationDTO>>> getMyReservations(
-			@Parameter(description = "요청한 사용자 ID") @UserId Long userId,
-			@CheckPage @RequestParam(name = "page", defaultValue = "1") int page,
-			@CheckPageSize @RequestParam(name = "size", defaultValue = "10") int size
+		@Parameter(description = "요청한 사용자 ID") @UserId Long userId,
+		@CheckPage @RequestParam(name = "page", defaultValue = "1") int page,
+		@CheckPageSize @RequestParam(name = "size", defaultValue = "10") int size
 	) {
 		Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "startDate"));
 		Page<ReservationResponseDTO.MyReservationDTO> result = reservationService.getMyReservations(userId, pageable);
@@ -56,18 +63,19 @@ public class ReservationController {
 	@GetMapping("/{id}")
 	@Operation(summary = "예약 상세 조회 API", description = "예약 ID를 기준으로 상세 정보를 조회합니다.")
 	public ResponseEntity<ApiResponse<ReservationResponseDTO.ReservationDetailDTO>> getReservationDetail(
-			@Parameter(description = "요청한 사용자 ID") @UserId Long userId,
-			@PathVariable("id") Long reservationId
+		@Parameter(description = "요청한 사용자 ID") @UserId Long userId,
+		@PathVariable("id") Long reservationId
 	) {
-		ReservationResponseDTO.ReservationDetailDTO result = reservationService.getReservationDetail(reservationId, userId);
+		ReservationResponseDTO.ReservationDetailDTO result = reservationService.getReservationDetail(reservationId,
+			userId);
 		return ResponseEntity.ok(ApiResponse.success(result));
 	}
 
 	@PatchMapping("/{id}")
 	@Operation(summary = "예약 취소 API", description = "예약 ID를 기준으로 사용자의 예약을 취소합니다.")
 	public ResponseEntity<ApiResponse<Void>> cancelReservation(
-			@Parameter(description = "요청한 사용자 ID") @UserId Long userId,
-			@PathVariable("id") Long reservationId
+		@Parameter(description = "요청한 사용자 ID") @UserId Long userId,
+		@PathVariable("id") Long reservationId
 	) {
 		reservationService.cancelReservation(reservationId, userId);
 		return ResponseEntity.ok(ApiResponse.success(null));

--- a/src/main/java/com/sumte/reservation/converter/ReservationConverter.java
+++ b/src/main/java/com/sumte/reservation/converter/ReservationConverter.java
@@ -1,16 +1,16 @@
 package com.sumte.reservation.converter;
 
-import com.sumte.guesthouse.entity.Guesthouse;
+import java.time.temporal.ChronoUnit;
+
 import org.springframework.stereotype.Component;
 
+import com.sumte.guesthouse.entity.Guesthouse;
 import com.sumte.reservation.dto.ReservationRequestDTO;
 import com.sumte.reservation.dto.ReservationResponseDTO;
 import com.sumte.reservation.entity.Reservation;
 import com.sumte.reservation.entity.ReservationStatus;
 import com.sumte.room.entity.Room;
 import com.sumte.user.entity.User;
-
-import java.time.temporal.ChronoUnit;
 
 @Component
 public class ReservationConverter {
@@ -33,45 +33,48 @@ public class ReservationConverter {
 			.build();
 	}
 
-	public ReservationResponseDTO.MyReservationDTO toMyReservationDTO(Reservation reservation, boolean canWriteReview, boolean reviewWritten) {
+	public ReservationResponseDTO.MyReservationDTO toMyReservationDTO(Reservation reservation, String firstRoomImageUrl,
+		boolean canWriteReview,
+		boolean reviewWritten) {
 		Room room = reservation.getRoom();
 		Guesthouse guestHouse = room.getGuesthouse();
-		int nightCount = (int) ChronoUnit.DAYS.between(reservation.getStartDate(), reservation.getEndDate());
+		int nightCount = (int)ChronoUnit.DAYS.between(reservation.getStartDate(), reservation.getEndDate());
 
 		return ReservationResponseDTO.MyReservationDTO.builder()
-				.id(reservation.getId())
-				.guestHouseName(guestHouse.getName())
-				.roomName(room.getName())
-				.imageUrl(room.getImageUrl())
-				.startDate(reservation.getStartDate())
-				.endDate(reservation.getEndDate())
-				.adultCount(reservation.getAdultCount())
-				.childCount(reservation.getChildCount())
-				.nightCount(nightCount)
-				.status(reservation.getReservationStatus())
-				.canWriteReview(canWriteReview)
-				.reviewWritten(reviewWritten)
-				.build();
+			.id(reservation.getId())
+			.guestHouseName(guestHouse.getName())
+			.roomName(room.getName())
+			.imageUrl(firstRoomImageUrl)
+			.startDate(reservation.getStartDate())
+			.endDate(reservation.getEndDate())
+			.adultCount(reservation.getAdultCount())
+			.childCount(reservation.getChildCount())
+			.nightCount(nightCount)
+			.status(reservation.getReservationStatus())
+			.canWriteReview(canWriteReview)
+			.reviewWritten(reviewWritten)
+			.build();
 	}
 
-	public ReservationResponseDTO.ReservationDetailDTO toReservationDetailDTO(Reservation reservation) {
+	public ReservationResponseDTO.ReservationDetailDTO toReservationDetailDTO(Reservation reservation,
+		String firstRoomImageUrl) {
 		Room room = reservation.getRoom();
 		Guesthouse guestHouse = room.getGuesthouse();
-		int nightCount = (int) ChronoUnit.DAYS.between(reservation.getStartDate(), reservation.getEndDate());
+		int nightCount = (int)ChronoUnit.DAYS.between(reservation.getStartDate(), reservation.getEndDate());
 
 		return ReservationResponseDTO.ReservationDetailDTO.builder()
-				.reservationId(reservation.getId())
-				.guestHouseName(guestHouse.getName())
-				.roomName(room.getName())
-				.imageUrl(room.getImageUrl())
-				.adultCount(reservation.getAdultCount())
-				.childCount(reservation.getChildCount())
-				.startDate(reservation.getStartDate())
-				.endDate(reservation.getEndDate())
-				.status(reservation.getReservationStatus().name())
-				.totalPrice(room.getPrice())
-				.nightCount(nightCount)
-				.reservedAt(reservation.getCreatedAt())
-				.build();
+			.reservationId(reservation.getId())
+			.guestHouseName(guestHouse.getName())
+			.roomName(room.getName())
+			.imageUrl(firstRoomImageUrl)
+			.adultCount(reservation.getAdultCount())
+			.childCount(reservation.getChildCount())
+			.startDate(reservation.getStartDate())
+			.endDate(reservation.getEndDate())
+			.status(reservation.getReservationStatus().name())
+			.totalPrice(room.getPrice())
+			.nightCount(nightCount)
+			.reservedAt(reservation.getCreatedAt())
+			.build();
 	}
 }

--- a/src/main/java/com/sumte/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/sumte/reservation/service/ReservationServiceImpl.java
@@ -1,34 +1,37 @@
 package com.sumte.reservation.service;
 
-import com.sumte.apiPayload.code.error.CommonErrorCode;
-import com.sumte.apiPayload.code.error.ReservationErrorCode;
-import com.sumte.apiPayload.exception.SumteException;
-import com.sumte.payment.entity.Payment;
-import com.sumte.payment.entity.PaymentStatus;
-import com.sumte.payment.repository.PaymentRepository;
-import com.sumte.reservation.entity.ReservationStatus;
-import com.sumte.review.repository.ReviewRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.sumte.apiPayload.code.error.CommonErrorCode;
+import com.sumte.apiPayload.code.error.ReservationErrorCode;
+import com.sumte.apiPayload.exception.SumteException;
+import com.sumte.image.entity.Image;
+import com.sumte.image.entity.OwnerType;
+import com.sumte.image.repository.ImageRepository;
+import com.sumte.payment.entity.Payment;
+import com.sumte.payment.entity.PaymentStatus;
+import com.sumte.payment.repository.PaymentRepository;
 import com.sumte.reservation.converter.ReservationConverter;
 import com.sumte.reservation.dto.ReservationRequestDTO;
 import com.sumte.reservation.dto.ReservationResponseDTO;
 import com.sumte.reservation.entity.Reservation;
+import com.sumte.reservation.entity.ReservationStatus;
 import com.sumte.reservation.repository.ReservationRepository;
+import com.sumte.review.repository.ReviewRepository;
 import com.sumte.room.entity.Room;
 import com.sumte.room.repository.RoomRepository;
 import com.sumte.user.entity.User;
 import com.sumte.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -40,17 +43,20 @@ public class ReservationServiceImpl implements ReservationService {
 	private final UserRepository userRepository;
 	private final PaymentRepository paymentRepository;
 	private final ReviewRepository reviewRepository;
+	private final ImageRepository imageRepository;
 
 	@Override
 	@Transactional
-	public ReservationResponseDTO.CreateReservationDTO createReservation(ReservationRequestDTO.CreateReservationDTO request, Long userId) {
+	public ReservationResponseDTO.CreateReservationDTO createReservation(
+		ReservationRequestDTO.CreateReservationDTO request, Long userId) {
 		User user = userRepository.findById(userId)
-				.orElseThrow(() -> new SumteException(CommonErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new SumteException(CommonErrorCode.USER_NOT_FOUND));
 		Room room = roomRepository.findById(request.getRoomId())
-				.orElseThrow(() -> new SumteException(ReservationErrorCode.ROOM_NOT_FOUND));
+			.orElseThrow(() -> new SumteException(ReservationErrorCode.ROOM_NOT_FOUND));
 
 		// 닐짜 유효성 검사
-		if (request.getStartDate().isAfter(request.getEndDate()) || request.getStartDate().isEqual(request.getEndDate())) {
+		if (request.getStartDate().isAfter(request.getEndDate()) || request.getStartDate()
+			.isEqual(request.getEndDate())) {
 			throw new SumteException(ReservationErrorCode.RESERVATION_DATE_INVALID);
 		}
 		// 정원 초과 검사
@@ -59,12 +65,13 @@ public class ReservationServiceImpl implements ReservationService {
 			throw new SumteException(ReservationErrorCode.ROOM_CAPACITY_EXCEEDED);
 		}
 		// 중복 예약 검사
-		boolean isOverlapping = reservationRepository.existsOverlappingReservation(room, request.getStartDate(), request.getEndDate());
-		if(isOverlapping) {
+		boolean isOverlapping = reservationRepository.existsOverlappingReservation(room, request.getStartDate(),
+			request.getEndDate());
+		if (isOverlapping) {
 			throw new SumteException(ReservationErrorCode.ALREADY_RESERVED);
 		}
 
-		Reservation reservation = reservationConverter.toEntity(request,user,room);
+		Reservation reservation = reservationConverter.toEntity(request, user, room);
 		reservationRepository.save(reservation);
 		return reservationConverter.toCreateResponse(reservation);
 	}
@@ -73,16 +80,28 @@ public class ReservationServiceImpl implements ReservationService {
 	@Transactional(readOnly = true)
 	public Page<ReservationResponseDTO.MyReservationDTO> getMyReservations(Long userId, Pageable pageable) {
 		User user = userRepository.findById(userId)
-				.orElseThrow(() -> new SumteException(CommonErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new SumteException(CommonErrorCode.USER_NOT_FOUND));
 
 		Page<Reservation> reservations = reservationRepository.findAllByUser(user, pageable);
 		return reservations.map(reservation -> {
 			boolean isComplete = reservation.getReservationStatus().equals(ReservationStatus.COMPLETED);
 
-			boolean reviewWritten = reviewRepository.existsByUserIdAndRoomGuesthouseId(user.getId(), reservation.getRoom().getGuesthouse().getId());
+			boolean reviewWritten = reviewRepository.existsByUserIdAndRoomGuesthouseId(user.getId(),
+				reservation.getRoom().getGuesthouse().getId());
 			boolean canWriteReview = isComplete && !reviewWritten;
 
-			return reservationConverter.toMyReservationDTO(reservation,canWriteReview,reviewWritten);
+			// 첫 번째 방 이미지 URL 조회
+			String firstImageUrl = imageRepository
+				.findByOwnerTypeAndOwnerIdOrderBySortOrderAsc(
+					OwnerType.ROOM,
+					reservation.getRoom().getId()
+				)
+				.stream()
+				.map(Image::getUrl)
+				.findFirst()
+				.orElse(null);
+
+			return reservationConverter.toMyReservationDTO(reservation, firstImageUrl, canWriteReview, reviewWritten);
 		});
 	}
 
@@ -90,20 +109,31 @@ public class ReservationServiceImpl implements ReservationService {
 	@Transactional(readOnly = true)
 	public ReservationResponseDTO.ReservationDetailDTO getReservationDetail(Long reservationId, Long userId) {
 		Reservation reservation = reservationRepository.findById(reservationId)
-				.orElseThrow(() -> new SumteException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+			.orElseThrow(() -> new SumteException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
 		if (!reservation.getUser().getId().equals(userId)) {
 			throw new SumteException(CommonErrorCode.FORBIDDEN);
 		}
 
-		return reservationConverter.toReservationDetailDTO(reservation);
+		// 첫 번째 방 이미지 URL 조회
+		String firstImageUrl = imageRepository
+			.findByOwnerTypeAndOwnerIdOrderBySortOrderAsc(
+				OwnerType.ROOM,
+				reservation.getRoom().getId()
+			)
+			.stream()
+			.map(Image::getUrl)
+			.findFirst()
+			.orElse(null);
+
+		return reservationConverter.toReservationDetailDTO(reservation, firstImageUrl);
 	}
 
 	@Override
 	@Transactional
 	public void cancelReservation(Long reservationId, Long userId) {
 		Reservation reservation = reservationRepository.findById(reservationId)
-				.orElseThrow(() -> new SumteException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+			.orElseThrow(() -> new SumteException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
 		// 사용자 본인 확인
 		if (!reservation.getUser().getId().equals(userId)) {
@@ -129,14 +159,15 @@ public class ReservationServiceImpl implements ReservationService {
 
 			boolean isAfterCheckout = endDate.isBefore(today) || (endDate.isEqual(today) && checkoutTime.isBefore(now));
 
-			if (!isAfterCheckout) continue;
+			if (!isAfterCheckout)
+				continue;
 
 			Optional<Payment> paymentOpt = paymentRepository.findByReservation(reservation);
 
 			boolean isPaid = paymentOpt
-					.map(Payment::getPaymentStatus)
-					.filter(status -> status == PaymentStatus.PAID)
-					.isPresent();
+				.map(Payment::getPaymentStatus)
+				.filter(status -> status == PaymentStatus.PAID)
+				.isPresent();
 
 			if (isPaid) {
 				reservation.complete();

--- a/src/main/java/com/sumte/review/controller/ReviewController.java
+++ b/src/main/java/com/sumte/review/controller/ReviewController.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 
 @Tag(name = "리뷰", description = "리뷰 관련 API")
 @RestController
-@RequestMapping("/api/reviews")
+@RequestMapping("reviews")
 @RequiredArgsConstructor
 public class ReviewController {
 
@@ -35,29 +35,29 @@ public class ReviewController {
 
 	@Operation(summary = "리뷰 등록")
 	@PostMapping
-	public ResponseEntity<Void> createReview(
+	public ResponseEntity<Long> createReview(
 		@UserId Long userId,
 		@RequestBody @Valid ReviewRequestDto dto) {
-		reviewService.createReview(userId, dto.getRoomId(), dto);
-		return ResponseEntity.noContent().build();
+		Long reviewId = reviewService.createReview(userId, dto);
+		return ResponseEntity.ok(reviewId);
 	}
 
 	@Operation(summary = "리뷰 수정")
-	@PatchMapping("/{id}")
-	public ResponseEntity<Void> updateReview(
+	@PatchMapping("/{reviewId}")
+	public ResponseEntity<Long> updateReview(
 		@UserId Long userId,
-		@PathVariable Long id,
+		@PathVariable Long reviewId,
 		@RequestBody @Valid ReviewRequestDto dto) {
-		reviewService.updateReview(userId, id, dto);
-		return ResponseEntity.noContent().build();
+		reviewService.updateReview(userId, reviewId, dto);
+		return ResponseEntity.ok(reviewId);
 	}
 
 	@Operation(summary = "리뷰 삭제")
-	@DeleteMapping("/{id}")
+	@DeleteMapping("/{reviewId}")
 	public ResponseEntity<Void> deleteReview(
 		@UserId Long userId,
-		@PathVariable Long id) {
-		reviewService.deleteReview(userId, id);
+		@PathVariable Long reviewId) {
+		reviewService.deleteReview(userId, reviewId);
 		return ResponseEntity.noContent().build();
 	}
 
@@ -74,7 +74,7 @@ public class ReviewController {
 	}
 
 	@Operation(summary = "내가 남긴 리뷰 전체 조회")
-	@GetMapping("/myreviews")
+	@GetMapping("/myReviews")
 	public ResponseEntity<Page<ReviewSearchDto>> getMyReviews(
 		@UserId Long userId,
 		@ParameterObject

--- a/src/main/java/com/sumte/review/converter/ReviewConverter.java
+++ b/src/main/java/com/sumte/review/converter/ReviewConverter.java
@@ -12,14 +12,12 @@ public class ReviewConverter {
 		return Review.builder()
 			.user(user)
 			.room(room)
-			.imageUrl(dto.getImageUrl())
 			.contents(dto.getContents())
 			.score(dto.getScore())
 			.build();
 	}
 
 	public static void updateEntity(Review review, ReviewRequestDto dto) {
-		review.changeImageUrl(dto.getImageUrl());
 		review.changeContents(dto.getContents());
 		review.changeScore(dto.getScore());
 	}
@@ -29,7 +27,6 @@ public class ReviewConverter {
 			review.getId(),
 			review.getUser().getId(),
 			review.getRoom().getId(),
-			review.getImageUrl(),
 			review.getContents(),
 			review.getScore()
 		);

--- a/src/main/java/com/sumte/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/sumte/review/dto/ReviewRequestDto.java
@@ -18,8 +18,6 @@ public class ReviewRequestDto {
 	@NotNull
 	private Long roomId;
 
-	private String imageUrl;
-
 	@NotBlank
 	private String contents;
 

--- a/src/main/java/com/sumte/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/sumte/review/dto/ReviewResponseDto.java
@@ -13,7 +13,6 @@ public class ReviewResponseDto {
 	private Long id;
 	private Long userId;
 	private Long roomId;
-	private String imageUrl;
 	private String contents;
 	private int score;
 

--- a/src/main/java/com/sumte/review/dto/ReviewSearchDto.java
+++ b/src/main/java/com/sumte/review/dto/ReviewSearchDto.java
@@ -1,6 +1,7 @@
 package com.sumte.review.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ReviewSearchDto {
 	private Long id;
+	private List<String> imageUrls;
 	private String contents;
 	private int score;
 	private String authorNickname;

--- a/src/main/java/com/sumte/review/dto/ReviewSearchDto.java
+++ b/src/main/java/com/sumte/review/dto/ReviewSearchDto.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ReviewSearchDto {
 	private Long id;
-	private String imageUrl;
 	private String contents;
 	private int score;
 	private String authorNickname;

--- a/src/main/java/com/sumte/review/entity/Review.java
+++ b/src/main/java/com/sumte/review/entity/Review.java
@@ -35,21 +35,8 @@ public class Review extends BaseTimeEntity {
 	@JoinColumn(name = "room_id")
 	private Room room;
 
-	private String imageUrl;
 	private String contents;
 	private int score;
-
-	//도메인 메서드 추가
-	// 리뷰 작성 시 연관 관계 설정 -> 리뷰생성할때 방과 사용자가 묶여서 생성
-	public void assignUserAndRoom(User user, Room room) {
-		this.user = user;
-		this.room = room;
-	}
-
-	// 이미지 URL 변경
-	public void changeImageUrl(String imageUrl) {
-		this.imageUrl = imageUrl;
-	}
 
 	// 내용 변경
 	public void changeContents(String contents) {

--- a/src/main/java/com/sumte/review/service/ReviewService.java
+++ b/src/main/java/com/sumte/review/service/ReviewService.java
@@ -1,14 +1,22 @@
 package com.sumte.review.service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sumte.apiPayload.code.error.ReviewErrorCode;
 import com.sumte.apiPayload.exception.SumteException;
+import com.sumte.image.entity.Image;
+import com.sumte.image.entity.OwnerType;
+import com.sumte.image.repository.ImageRepository;
 import com.sumte.review.converter.ReviewConverter;
 import com.sumte.review.dto.ReviewRequestDto;
 import com.sumte.review.dto.ReviewSearchDto;
@@ -28,6 +36,7 @@ public class ReviewService {
 	private final ReviewRepository reviewRepository;
 	private final UserRepository userRepository;
 	private final RoomRepository roomRepository;
+	private final ImageRepository imageRepository;
 
 	@Transactional
 	public Long createReview(Long userId, ReviewRequestDto dto) {
@@ -69,29 +78,102 @@ public class ReviewService {
 		throw new SumteException(ReviewErrorCode.UNAUTHORIZED);
 	}
 
-	private ReviewSearchDto toListDto(Review r) {
-		return new ReviewSearchDto(
-			r.getId(),
-			r.getContents(),
-			r.getScore(),
-			r.getUser().getNickname(),
-			r.getCreatedAt()
-		);
-	}
-
 	@Transactional(readOnly = true)
 	public Page<ReviewSearchDto> getReviewsByGuesthouse(Long guesthouseId, Pageable pageable) {
-		return reviewRepository
-			.findAllByRoomGuesthouseId(guesthouseId, pageable)
-			.map(this::toListDto);
+		// 1) 페이징된 리뷰 조회
+		Page<Review> reviewPage = reviewRepository
+			.findAllByRoomGuesthouseId(guesthouseId, pageable);
+
+		List<Review> reviews = reviewPage.getContent();
+		if (reviews.isEmpty()) {
+			return Page.empty(pageable);
+		}
+
+		// 2) 리뷰 ID 리스트 뽑아서 이미지 일괄 조회
+		List<Long> reviewIds = reviews.stream()
+			.map(Review::getId)
+			.toList();
+
+		List<Image> images = imageRepository
+			.findByOwnerTypeAndOwnerIdInOrderByOwnerIdAscSortOrderAsc(
+				OwnerType.REVIEW, reviewIds
+			);
+
+		// 3) ownerId 별로 URL 그룹핑
+		Map<Long, List<String>> urlsByReview = images.stream()
+			.collect(Collectors.groupingBy(
+				Image::getOwnerId,
+				Collectors.mapping(Image::getUrl, Collectors.toList())
+			));
+
+		// 4) DTO 변환 (이미 없는 toListDto 대신 직접 매핑)
+		List<ReviewSearchDto> dtos = reviews.stream()
+			.map(r -> new ReviewSearchDto(
+				r.getId(),
+				urlsByReview.getOrDefault(r.getId(), Collections.emptyList()),
+				r.getContents(),
+				r.getScore(),
+				r.getUser().getNickname(),
+				r.getCreatedAt()
+			))
+			.toList();
+
+		// 5) PageImpl 으로 포장해서 반환
+		return new PageImpl<>(
+			dtos,
+			pageable,
+			reviewPage.getTotalElements()
+		);
 	}
 
 	//리뷰테이블에서 userid와 일치하는 모든 리뷰 가져오기, 이 각 엔티티->dto로 변환
 	@Transactional(readOnly = true)
 	public Page<ReviewSearchDto> getMyReviews(Long userId, Pageable pageable) {
-		return reviewRepository
-			.findAllByUserId(userId, pageable)
-			.map(this::toListDto);
-	}
+		// 1) 내가 쓴 리뷰 페이징 조회
+		Page<Review> reviewPage = reviewRepository
+			.findAllByUserId(userId, pageable);
 
+		List<Review> reviews = reviewPage.getContent();
+		if (reviews.isEmpty()) {
+			return Page.empty(pageable);
+		}
+
+		// 2) 리뷰 ID 리스트
+		List<Long> reviewIds = reviews.stream()
+			.map(Review::getId)
+			.toList();
+
+		// 3) 해당 리뷰들의 이미지 일괄 조회
+		List<Image> images = imageRepository
+			.findByOwnerTypeAndOwnerIdInOrderByOwnerIdAscSortOrderAsc(
+				OwnerType.REVIEW,
+				reviewIds
+			);
+
+		// 4) ownerId 별 URL 그룹핑
+		Map<Long, List<String>> urlsByReview = images.stream()
+			.collect(Collectors.groupingBy(
+				Image::getOwnerId,
+				Collectors.mapping(Image::getUrl, Collectors.toList())
+			));
+
+		// 5) DTO 변환
+		List<ReviewSearchDto> dtos = reviews.stream()
+			.map(r -> new ReviewSearchDto(
+				r.getId(),
+				urlsByReview.getOrDefault(r.getId(), Collections.emptyList()),
+				r.getContents(),
+				r.getScore(),
+				r.getUser().getNickname(),
+				r.getCreatedAt()
+			))
+			.toList();
+
+		// 6) PageImpl 포장
+		return new PageImpl<>(
+			dtos,
+			pageable,
+			reviewPage.getTotalElements()
+		);
+	}
 }

--- a/src/main/java/com/sumte/review/service/ReviewService.java
+++ b/src/main/java/com/sumte/review/service/ReviewService.java
@@ -11,7 +11,6 @@ import com.sumte.apiPayload.code.error.ReviewErrorCode;
 import com.sumte.apiPayload.exception.SumteException;
 import com.sumte.review.converter.ReviewConverter;
 import com.sumte.review.dto.ReviewRequestDto;
-import com.sumte.review.dto.ReviewResponseDto;
 import com.sumte.review.dto.ReviewSearchDto;
 import com.sumte.review.entity.Review;
 import com.sumte.review.repository.ReviewRepository;
@@ -31,7 +30,7 @@ public class ReviewService {
 	private final RoomRepository roomRepository;
 
 	@Transactional
-	public ReviewResponseDto createReview(Long userId, Long roomId, ReviewRequestDto dto) {
+	public Long createReview(Long userId, ReviewRequestDto dto) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new SumteException(ReviewErrorCode.USER_NOT_FOUND));
 		Room room = roomRepository.findById(dto.getRoomId())
@@ -39,19 +38,18 @@ public class ReviewService {
 
 		Review review = ReviewConverter.toEntity(dto, user, room);
 		Review saved = reviewRepository.save(review);
-		return ReviewConverter.toDto(saved);
+		return saved.getId();
 	}
 
 	@Transactional
-	public ReviewResponseDto updateReview(Long userId, Long id, ReviewRequestDto dto) {
-		Optional<Review> opt = reviewRepository.findByIdAndUserId(id, userId);
+	public Void updateReview(Long userId, Long reviewId, ReviewRequestDto dto) {
+		Optional<Review> opt = reviewRepository.findByIdAndUserId(reviewId, userId);
 		if (opt.isPresent()) {
 			Review review = opt.get();
 			ReviewConverter.updateEntity(review, dto);
-			return ReviewConverter.toDto(review);
 		}
-		// id 자체가 존재하지 않으면 NOT_FOUND로
-		if (!reviewRepository.existsById(id)) {
+		// reviewId 자체가 존재하지 않으면 NOT_FOUND로
+		if (!reviewRepository.existsById(reviewId)) {
 			throw new SumteException(ReviewErrorCode.REVIEW_NOT_FOUND);
 		}
 		// id는 있지만 userId가 다르면 UNAUTH로

--- a/src/main/java/com/sumte/review/service/ReviewService.java
+++ b/src/main/java/com/sumte/review/service/ReviewService.java
@@ -72,7 +72,6 @@ public class ReviewService {
 	private ReviewSearchDto toListDto(Review r) {
 		return new ReviewSearchDto(
 			r.getId(),
-			r.getImageUrl(),
 			r.getContents(),
 			r.getScore(),
 			r.getUser().getNickname(),

--- a/src/main/java/com/sumte/room/controller/RoomController.java
+++ b/src/main/java/com/sumte/room/controller/RoomController.java
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Room API", description = "room을 추가/수정/삭제 하는 api입니다")
+@Tag(name = "객실 API", description = "특정 게스트하우스의 객실을 추가/수정/삭제 하는 api입니다")
 @RequestMapping("/guesthouse")
 public class RoomController {
 	private final RoomCommandService roomCommandService;

--- a/src/main/java/com/sumte/room/controller/RoomController.java
+++ b/src/main/java/com/sumte/room/controller/RoomController.java
@@ -41,13 +41,12 @@ public class RoomController {
 	@Parameters({
 		@Parameter(name = "guesthouseId", description = "숙소 아이디를 넘겨주세요")
 	})
-	public ApiResponse<Void> registerRoom(
+	public ApiResponse<Long> registerRoom(
 		@PathVariable Long guesthouseId,
 		@RequestBody @Valid RoomRequestDTO.RegisterRoom dto) {
-		roomCommandService.registerRoom(dto, guesthouseId);
-
-		return ApiResponse.successWithNoData();
-
+		RoomResponseDTO.Registered room = roomCommandService.registerRoom(dto, guesthouseId);
+		Long roomId = room.getRoomId();
+		return ApiResponse.created(roomId);
 	}
 
 	@DeleteMapping("/{guesthouseId}/room/{roomId}")
@@ -71,12 +70,12 @@ public class RoomController {
 		@Parameter(name = "guesthouseId", description = "숙소 아이디를 넘겨주세요"),
 		@Parameter(name = "roomId", description = "방 아이디를 넘겨주세요.")
 	})
-	public ApiResponse<Void> updateRoom(
+	public ApiResponse<Long> updateRoom(
 		@PathVariable Long guesthouseId, @PathVariable Long roomId,
 		@RequestBody @Valid RoomRequestDTO.UpdateRoom dto
 	) {
 		roomCommandService.updateRoom(dto, guesthouseId, roomId);
-		return ApiResponse.successWithNoData();
+		return ApiResponse.success(roomId);
 	}
 
 	@GetMapping("/room/{roomId}")

--- a/src/main/java/com/sumte/room/converter/RoomConverter.java
+++ b/src/main/java/com/sumte/room/converter/RoomConverter.java
@@ -42,7 +42,6 @@ public class RoomConverter {
 			.id(room.getId())
 			.name(room.getName())
 			.price(room.getPrice())
-			.imageUrl(room.getImageUrl())
 			.standardCount(room.getStandardCount())
 			.totalCount(room.getTotalCount())
 			.checkin(room.getCheckin())

--- a/src/main/java/com/sumte/room/dto/RoomRequestDTO.java
+++ b/src/main/java/com/sumte/room/dto/RoomRequestDTO.java
@@ -32,9 +32,6 @@ public class RoomRequestDTO {
 
 		@NotNull(message = "최대 인원을 입력해주세요")
 		Long totalCount;
-
-		String imageUrl;
-
 	}
 
 	@Getter
@@ -48,7 +45,5 @@ public class RoomRequestDTO {
 		LocalTime checkout;
 		Long standardCount;
 		Long totalCount;
-		String imageUrl;
 	}
-
 }

--- a/src/main/java/com/sumte/room/dto/RoomResponseDTO.java
+++ b/src/main/java/com/sumte/room/dto/RoomResponseDTO.java
@@ -1,6 +1,7 @@
 package com.sumte.room.dto;
 
 import java.time.LocalTime;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,7 +47,7 @@ public class RoomResponseDTO {
 		String content;
 		LocalTime checkin;
 		LocalTime checkout;
-		String imageUrl;
+		List<String> imageUrls;
 	}
 
 	@NoArgsConstructor

--- a/src/main/java/com/sumte/room/dto/RoomResponseDTO.java
+++ b/src/main/java/com/sumte/room/dto/RoomResponseDTO.java
@@ -50,6 +50,22 @@ public class RoomResponseDTO {
 		List<String> imageUrls;
 	}
 
+	@Builder
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class GetPreviewRoomByGuesthouseResponse {
+		Long id;
+		String name;
+		Long price;
+		Long standardCount;
+		Long totalCount;
+		String content;
+		LocalTime checkin;
+		LocalTime checkout;
+		String imageUrl;
+	}
+
 	@NoArgsConstructor
 	@Getter
 	@AllArgsConstructor

--- a/src/main/java/com/sumte/room/entity/Room.java
+++ b/src/main/java/com/sumte/room/entity/Room.java
@@ -35,7 +35,6 @@ public class Room extends BaseTimeEntity {
 	private LocalTime checkout;
 	private Long standardCount;
 	private Long totalCount;
-	private String imageUrl;
 
 	public static Room createRoomEntity(RoomRequestDTO.RegisterRoom dto) {
 		Room room = new Room();
@@ -46,7 +45,6 @@ public class Room extends BaseTimeEntity {
 		room.checkout = dto.getCheckout();
 		room.standardCount = dto.getStandardCount();
 		room.totalCount = dto.getTotalCount();
-		room.imageUrl = dto.getImageUrl();
 		return room;
 	}
 
@@ -81,9 +79,4 @@ public class Room extends BaseTimeEntity {
 	public void setTotalCount(Long totalCount) {
 		this.totalCount = totalCount;
 	}
-
-	public void setImageUrl(String imageUrl) {
-		this.imageUrl = imageUrl;
-	}
-
 }

--- a/src/main/java/com/sumte/room/service/RoomCommandServiceImpl.java
+++ b/src/main/java/com/sumte/room/service/RoomCommandServiceImpl.java
@@ -87,9 +87,6 @@ public class RoomCommandServiceImpl implements RoomCommandService {
 		if (dto.getTotalCount() != null) {
 			room.setTotalCount(dto.getTotalCount());
 		}
-		if (dto.getImageUrl() != null) {
-			room.setImageUrl(dto.getImageUrl());
-		}
 
 		return roomConverter.toUpdateEntity(room);
 

--- a/src/main/java/com/sumte/security/controller/SignInController.java
+++ b/src/main/java/com/sumte/security/controller/SignInController.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "로그인 API", description = "로그인 API입니다.")
+@Tag(name = "회원가입/로그인 API", description = "회원가입/로그인 관련 API입니다.")
 @RestController
 @RequestMapping("/users/login")
 @RequiredArgsConstructor

--- a/src/main/java/com/sumte/security/controller/SignUpController.java
+++ b/src/main/java/com/sumte/security/controller/SignUpController.java
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "회원가입 API", description = "회원가입 API입니다.")
+@Tag(name = "회원가입/로그인 API", description = "회원가입/로그인 관련 API입니다.")
 @RestController
 @RequestMapping("/users/signup")
 @RequiredArgsConstructor

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,6 +28,7 @@ cloud:
       secret-key: ${S3_SECRET_KEY}
     s3:
       bucket: sumte-file
+      url-prefix: https://sumte-file.s3.ap-northeast-2.amazonaws.com
     stack:
       auto: false
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #50

## ✨ PR 세부 내용

### 1. 주요 변경 사항
1. **단일 `image` 테이블 도입**
    - Guesthouse, Room, Review의 이미지를 `(owner_type, owner_id)` 로 구분해 한 곳에서 통합 관리
    - 이미지는 객체 소유자 타입 ownerType + 객체 PK ownerId로 구분
2. **배치 업로드 & 자동 정렬 순서 부여**
    -  Presigned-URL API, 이미지 API 에서 다중 파일명 한 번에 발급
    - 이미지 등록 시 owner별로 그룹핑 후 입력된 순서대로 sort 배정(서버에서 자동 부여)
    -  썸네일은 맨 첫번째로 등록된 이미지가 썸네일이 되도록 지정
3. **이미지 메타 CRUD API**
    - `POST /images` : 한 번에 여러 이미지 등록 가능
    - `PUT /images/{ownerType}/{ownerId}` : 전체 교체(교체 시 사용되지 않는 S3 객체·DB 레코드 삭제 + 새 이미지 일괄 저장)
    - `GET /images` : 특정 객체의 이미지 조회 가능. 기존 조회에서 이미지 조회도 같이 하도록 수정해서 딱히 필요는 없음
    - 등록 및 수정 시 한 번에 여러 이미지 등록 가능하도록 batch 처리
4. **생성 API에서 PK(id) 반환**
    - 게스트하우스, 객실, 리뷰 생성 시 모두 `고유 Id(PK)` 반환
    - 반환된 id -> 이미지 등록 시 ownerId에 매핑하여 작동 가능
5. **조회 API에 이미지 합치기**
    -  게스트하우스, 객실, 리뷰, 예약 조회 시 관련 이미지도 함께 조회하도록 전반적인 조회 로직 수정
    - **상세 조회**
        - 게스트하우스: 모든 이미지 URL 리스트
        - 각 Room: 첫 번째 이미지(썸네일) 1장
    - **홈/검색 리스트**: 각 게스트하우스 대표 이미지 1장 포함
    - **객실 상세**: 해당 룸의 모든 이미지 URL 리스트
    - **내 예약 목록**: 각 예약의 룸별 첫 번째 이미지 1장
6. **S3 키 네이밍·정리**
    - 객체 키: `UUID_ownerType_ownerId_yyyyMMdd…` 형식으로 고유 생성
        - s3 구조 관리 및 파일명 중복 막기 위해 uuid + 이미지 소유 테이블 + 테이블 Id + 날짜 조합으로 고유 키 생성
    - 교체·차등 업데이트 시 사용되지 않은 S3 객체는 `DeleteObjects` 로 일괄 삭제
7. **S3 presignedURL**
    - presignedURL 파일 형식 입력 및 업로드 제한 삭제
    - presiginedURL API 발급 시 (기존) presignedURL만 제공 -> (변경 후) 원본 파일명, 이미지 URL, presignedURL 모두 제공하여 편의성 증대
    - (기존) 한번에 presignedURL 한 개만 발급 가능 -> (변경 후) 한번에 복수의 presigned-url 발급 가능
8. **Swagger/OpenAPI 문서 정리**
    - `/images` 엔드포인트 전체 스펙 추가 및 예시 개선
    - Presigned-URL 쿼리 파라미터(멀티값) 설명 보강
    - 영어 태그 삭제 및 파편하된 태그 통합으로 전반적인 스웨거 가독성 증대
9. **코드 리팩토링**
    - 엔티티/DTO에서 구 `imageUrl: String` 필드 제거, `List<String> imageUrls` 또는 대표 이미지 필드(첫번째 업로드 이미지)로 대체
    - 각종 불필요한 코드 리팩토링

---

### 2. 검토 체크리스트 (추가 고려 사항)

- **테스트 보강**
    - 배치 등록·정렬 로직, 교체·삭제 흐름에 대한 단위/통합 테스트
    - 잘못된 ownerType/ownerId 처리(404), 중복 업로드(409) 등 예외 시나리오 검증
- **퍼포먼스 검토**
    - 대량 조회 시 N+1 방지(이미지 일괄 조회) 확인
    - 이미지 리스트 페이징 필요성 검토
- **모니터링·알림**
    - S3 삭제 실패 모니터링
    - 이미지 테이블 크기 및 사용량 경고 설정


<!-- 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능) -->
<!-- 구현 기능 요약 -->
<!-- 주요 변경사항 -->

## ✅ 체크리스트

- [x] 빌드 및 테스트 통과
- [x] 주요 기능 정상 동작
